### PR TITLE
Set default MaxMetaspaceSize to 200m

### DIFF
--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -67,7 +67,7 @@ fi
 
 if [ -z $JAVA_GC_OPTS ]; then
   # note - MaxPermSize no longer valid with v8 of the jdk ... used to have -XX:MaxPermSize=100m
-  JAVA_GC_OPTS="-XX:+UseParallelGC -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"
+  JAVA_GC_OPTS="-XX:+UseParallelGC -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=${MAX_METASPACE_SIZE}"
 fi
 
 if [ ! -z "${USE_JAVA_DIAGNOSTICS}" ]; then

--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -35,7 +35,7 @@ CONTAINER_MEMORY_IN_BYTES=`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`
 DEFAULT_MEMORY_CEILING=$((2**40-1))
 
 if [ -z $MAX_METASPACE_SIZE ]; then
-    MAX_METASPACE_SIZE=100m
+    MAX_METASPACE_SIZE=200m
 fi
 
 if [ "${CONTAINER_MEMORY_IN_BYTES}" -lt "${DEFAULT_MEMORY_CEILING}" ]; then


### PR DESCRIPTION
`MaxMetaspaceSize=100m` is too lean for "Release and Stage" pipeline (it's perfectly sufficient for simpler "Release" pipeline though). Simply commenting out one step in the pipeline (for example `bayesianAnalysis` or `kubernetesApply` step) decreases class metadata memory footprint and therefore the pipeline then fits into the 100m size limit.

This PR makes the MaxMetaspaceSize parametrised again and sets the default value to 200m. I was able to do 131 builds with this setting. Build #132 failed due to `No space left on device` error.

200m should give us plenty of room for further pipeline expansions. However, if the default value is too high, then we could go as low as to 120m.