### PR TITLE
Fix OpenJDK settings so as to use less memory.

### DIFF
--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -56,18 +56,17 @@ if [ "${CONTAINER_MEMORY_IN_BYTES}" -lt "${DEFAULT_MEMORY_CEILING}" ]; then
     fi
     
     JAVA_MAX_HEAP_PARAM="-Xmx${CONTAINER_HEAP_MAX}m"
-    if [ -z $CONTAINTER_INITIAL_PERCENT ]; then
-	# jboss default was 100% or ms==mx
-	JAVA_INITIAL_HEAP_PARAM="-Xms${CONTAINER_HEAP_MAX}m"
-    else
-	CONTAINER_INITIAL_HEAP=$(echo "${CONTAINER_HEAP_MAX} ${CONTAINER_INITIAL_PERCENT}" | awk '{ printf "%d", $1 * $2 }')
-	JAVA_INITIAL_HEAP_PARAM="-Xms${CONTAINER_INITIAL_HEAP}m"
+    if [ -z $CONTAINER_INITIAL_PERCENT ]; then
+      CONTAINER_INITIAL_PERCENT=0.07
     fi
-fi 
+    CONTAINER_INITIAL_HEAP=$(echo "${CONTAINER_HEAP_MAX} ${CONTAINER_INITIAL_PERCENT}" | awk '{ printf "%d", $1 * $2 }')
+    JAVA_INITIAL_HEAP_PARAM="-Xms${CONTAINER_INITIAL_HEAP}m"
+fi
 
-if [ -z $JAVA_GC_OPTS ]; then
-  # note - MaxPermSize no longer valid with v8 of the jdk ... used to have -XX:MaxPermSize=100m
-  JAVA_GC_OPTS="-XX:+UseParallelGC -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"
+if [ -z "$JAVA_GC_OPTS" ]; then
+    # We no longer set MaxMetaspaceSize because the JVM should expand metaspace until it reaches the container limit.
+    # See http://hg.openjdk.java.net/jdk8u/jdk8u/hotspot/file/4dd24f4ca140/src/share/vm/memory/metaspace.cpp#l1470
+    JAVA_GC_OPTS="-XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"
 fi
 
 if [ ! -z "${USE_JAVA_DIAGNOSTICS}" ]; then
@@ -76,6 +75,10 @@ fi
 
 if [ ! -z "${CONTAINER_CORE_LIMIT}" ]; then
     JAVA_CORE_LIMIT="-XX:ParallelGCThreads=${CONTAINER_CORE_LIMIT} -Djava.util.concurrent.ForkJoinPool.common.parallelism=${CONTAINER_CORE_LIMT} -XX:CICompilerCount=2"
+fi
+
+if [ -z "${JAVA_OPTS}" ]; then
+    JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true"
 fi
 
 # Since OpenShift runs this Docker image under random user ID, we have to assign

--- a/slave-base/contrib/bin/run-jnlp-client
+++ b/slave-base/contrib/bin/run-jnlp-client
@@ -68,26 +68,35 @@ if [[ $# -gt 1 ]]; then
   DEFAULT_MEMORY_CEILING=$((2**40-1))
   if [ "${CONTAINER_MEMORY_IN_BYTES}" -lt "${DEFAULT_MEMORY_CEILING}" ]; then
 
-      if [ -z $CONTAINER_HEAP_PERCENT ]; then
-              CONTAINER_HEAP_PERCENT=0.50
-      fi
-      
-      CONTAINER_MEMORY_IN_MB=$((${CONTAINER_MEMORY_IN_BYTES}/1024**2))
-      CONTAINER_HEAP_MAX=$(echo "${CONTAINER_MEMORY_IN_MB} ${CONTAINER_HEAP_PERCENT}" | awk '{ printf "%d", $1 * $2 }')      
-      JAVA_MAX_HEAP_PARAM="-Xmx${CONTAINER_HEAP_MAX}m"
-      if [-z $CONTAINTER_INITIAL_PERCENT]; then
-	  # jboss default was 100% or ms==mx
-	  JAVA_INITIAL_HEAP_PARAM="-Xms${CONTAINER_HEAP_MAX}m"
-      else
-	  CONTAINER_INITIAL_HEAP=$(echo "${CONTAINER_HEAP_MAX} ${CONTAINER_INITIAL_PERCENT}" | awk '{ printf "%d", $1 * $2 }')
-	  JAVA_INITIAL_HEAP_PARAM="-Xms${CONTAINER_INITIAL_HEAP}m"
-      fi
-  fi 
+    if [ -z $CONTAINER_HEAP_PERCENT ]; then
+        CONTAINER_HEAP_PERCENT=0.50
+    fi
 
-  if [ -z $JAVA_GC_OPTS ]; then
-    JAVA_GC_OPTS="-XX:+UseParallelGC -XX:MaxPermSize=100m -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m"
+    CONTAINER_MEMORY_IN_MB=$((${CONTAINER_MEMORY_IN_BYTES}/1024**2))
+    #if machine has 4GB or less, meaning max heap of 2GB given current default, force use of 32bit to save space unless user
+    #specifically want to force 64bit
+    HEAP_LIMIT_FOR_32BIT=$((2**32-1))
+    HEAP_LIMIT_FOR_32BIT_IN_MB=$((${HEAP_LIMIT_FOR_32BIT}/1024**2))
+    CONTAINER_HEAP_MAX=$(echo "${CONTAINER_MEMORY_IN_MB} ${CONTAINER_HEAP_PERCENT}" | awk '{ printf "%d", $1 * $2 }')
+    if [[ -z $OPENSHIFT_JENKINS_JVM_ARCH && "${CONTAINER_HEAP_MAX}" -lt "${HEAP_LIMIT_FOR_32BIT_IN_MB}"  ]]; then
+      echo "max heap in MB is ${CONTAINER_HEAP_MAX} and 64 bit was not explicitly set so using 32 bit Java"
+      alternatives --set java $JVMPath32bit
+      export MALLOC_ARENA_MAX=1
+    fi
+
+    JAVA_MAX_HEAP_PARAM="-Xmx${CONTAINER_HEAP_MAX}m"
+    if [ -z $CONTAINER_INITIAL_PERCENT ]; then
+      CONTAINER_INITIAL_PERCENT=0.07
+    fi
+    CONTAINER_INITIAL_HEAP=$(echo "${CONTAINER_HEAP_MAX} ${CONTAINER_INITIAL_PERCENT}" | awk '{ printf "%d", $1 * $2 }')
+    JAVA_INITIAL_HEAP_PARAM="-Xms${CONTAINER_INITIAL_HEAP}m"
   fi
 
+  if [ -z $JAVA_GC_OPTS ]; then
+      # We no longer set MaxMetaspaceSize because the JVM should expand metaspace until it reaches the container limit.
+      # See http://hg.openjdk.java.net/jdk8u/jdk8u/hotspot/file/4dd24f4ca140/src/share/vm/memory/metaspace.cpp#l1470
+      JAVA_GC_OPTS="-XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"
+  fi
 
   if [ ! -z "${USE_JAVA_DIAGNOSTICS}" ]; then
       JAVA_DIAGNOSTICS="-XX:NativeMemoryTracking=summary -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UnlockDiagnosticVMOptions"
@@ -95,6 +104,10 @@ if [[ $# -gt 1 ]]; then
 
   if [ ! -z "${CONTAINER_CORE_LIMIT}" ]; then
       JAVA_CORE_LIMIT="-XX:ParallelGCThreads=${CONTAINER_CORE_LIMIT} -Djava.util.concurrent.ForkJoinPool.common.parallelism=${CONTAINER_CORE_LIMT} -XX:CICompilerCount=2"
+  fi
+
+  if [ -z "${JAVA_OPTS}" ]; then
+      JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true"
   fi
 
   echo Running java $JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS $JAVA_OPTS -cp $JAR hudson.remoting.jnlp.Main -headless $PARAMS "$@"


### PR DESCRIPTION
- Fix JVM options for slave-base as well.
- Also remove MaxMetaspaceSize setting and
  rely on the JVM doing the sizing.