### PR TITLE
Removes execute bit set on /etc/passwd

### DIFF
--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -76,7 +76,7 @@ RUN /usr/local/bin/install-plugins.sh /opt/openshift/base-plugins.txt && \
     # Currently jenkins v2 does not embed any plugins, but for reference:
     # touch /opt/openshift/plugins/credentials.jpi.pinned && \
     rmdir /var/log/jenkins && \
-    chmod 775 /etc/passwd && \
+    chmod 664 /etc/passwd && \
     chmod -R 775 /etc/alternatives && \
     chmod -R 775 /var/lib/alternatives && \
     chmod -R 775 /usr/lib/jvm && \

--- a/2/Dockerfile.rhel7
+++ b/2/Dockerfile.rhel7
@@ -52,7 +52,7 @@ RUN rm /opt/openshift/base-plugins.txt && \
     # NOTE: When adding new Jenkins plugin, you have to create the symlink for the
     # HPI file created by rpm to /opt/openshift/plugins folder.
     for FILENAME in /usr/lib64/jenkins/*hpi ; do ln -s $FILENAME /opt/openshift/plugins/`basename $FILENAME .hpi`.jpi; done &&\
-    chmod 775 /etc/passwd && \
+    chmod 664 /etc/passwd && \
     chmod -R 775 /etc/alternatives && \
     chmod -R 775 /var/lib/alternatives && \
     chmod -R 775 /usr/lib/jvm && \

--- a/slave-base/Dockerfile
+++ b/slave-base/Dockerfile
@@ -15,7 +15,7 @@ RUN yum install -y centos-release-scl-rh && \
     mkdir -p /home/jenkins && \
     chown -R 1001:0 /home/jenkins && \
     chmod -R g+w /home/jenkins && \
-    chmod 775 /etc/passwd && \
+    chmod 664 /etc/passwd && \
     chmod -R 775 /etc/alternatives && \
     chmod -R 775 /var/lib/alternatives && \
     chmod -R 775 /usr/lib/jvm && \

--- a/slave-base/Dockerfile.rhel7
+++ b/slave-base/Dockerfile.rhel7
@@ -24,7 +24,7 @@ RUN yum-config-manager --disable epel >/dev/null || : && \
     mkdir -p /home/jenkins && \
     chown -R 1001:0 /home/jenkins && \
     chmod -R g+w /home/jenkins && \
-    chmod 775 /etc/passwd && \
+    chmod 664 /etc/passwd && \
     chmod -R 775 /etc/alternatives && \
     chmod -R 775 /var/lib/alternatives && \
     chmod -R 775 /usr/lib/jvm && \


### PR DESCRIPTION
Normally, the permission bits on `/etc/passwd` is `644` but in
our case it needs to be set to `664` as the `run` script adds an
entry into `/etc/passwd` at runtime with the UID of the user that
openshift is currently running the container as. The group-id of
the user seems to be `0` which is why we are setting the `read`
and `write` bits for the `group`

See also: https://github.com/fabric8-jenkins/jenkins-openshift-base/blob/8ca14b5970ce03342183184a2712ad398e7b58ad/2/contrib/jenkins/jenkins-common.sh#L13
Fixes: https://github.com/fabric8-jenkins/jenkins-openshift-base/issues/21