### PR TITLE
Setting <containerCap> flag to 1 to limit one slave pod at a time

### DIFF
--- a/1/contrib/jenkins/kube-slave-common.sh
+++ b/1/contrib/jenkins/kube-slave-common.sh
@@ -199,7 +199,7 @@ function generate_kubernetes_config() {
       <jenkinsUrl>http://${JENKINS_SERVICE_HOST}:${JENKINS_SERVICE_PORT}</jenkinsUrl>
       <jenkinsTunnel>${JNLP_HOST}:${JNLP_PORT}</jenkinsTunnel>
       <credentialsId>1a12dfa4-7fc5-47a7-aa17-cc56572a41c7</credentialsId>
-      <containerCap>10</containerCap>
+      <containerCap>1</containerCap>
       <retentionTimeout>5</retentionTimeout>
     </org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud>
     "

--- a/2/contrib/jenkins/kube-slave-common.sh
+++ b/2/contrib/jenkins/kube-slave-common.sh
@@ -199,7 +199,7 @@ function generate_kubernetes_config() {
       <jenkinsUrl>http://jenkins</jenkinsUrl>
       <jenkinsTunnel>jenkins-jnlp:${JNLP_PORT}</jenkinsTunnel>
       <credentialsId>1a12dfa4-7fc5-47a7-aa17-cc56572a41c7</credentialsId>
-      <containerCap>10</containerCap>
+      <containerCap>1</containerCap>
       <retentionTimeout>5</retentionTimeout>
     </org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud>
     "


### PR DESCRIPTION
Reducing the container cap so that with this only one job will be
triggered and all the other jobs will be queued which will not cause
failures of builds due to timeouts.

See discussion here:
1) https://github.com/openshiftio/openshift.io/issues/2384
2) https://github.com/openshiftio/openshift.io/issues/2729