### PR TITLE
GC tuning for slow jenkins startup

### DIFF
--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -170,7 +170,7 @@ fi
 if [ -z "$JAVA_GC_OPTS" ]; then
     # We no longer set MaxMetaspaceSize because the JVM should expand metaspace until it reaches the container limit.
     # See http://hg.openjdk.java.net/jdk8u/jdk8u/hotspot/file/4dd24f4ca140/src/share/vm/memory/metaspace.cpp#l1470
-    JAVA_GC_OPTS="-XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"
+    JAVA_GC_OPTS="-XX:+UseG1GC -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+AlwaysPreTouch -XX:+UseStringDeduplication -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"
 fi
 
 if [ ! -z "${USE_JAVA_DIAGNOSTICS}" ]; then


### PR DESCRIPTION
- using GC1GC insted of parallel GC
- added more flags to reduce slows bootup

Its experimental so please don't merge it.