### PR TITLE
Update Jenkins version

### DIFF
--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -13,7 +13,7 @@ FROM centos:centos7
 MAINTAINER Ben Parees <bparees@redhat.com>
 
 # Get newer unstable Jenkins from https://pkg.jenkins.io/redhat
-ENV JENKINS_VERSION=2.93-1.1 \
+ENV JENKINS_VERSION=2.138.2-1.1 \
     HOME=/var/lib/jenkins \
     JENKINS_HOME=/var/lib/jenkins \
     JENKINS_UC=https://updates.jenkins-ci.org
@@ -28,8 +28,8 @@ LABEL k8s.io.description="Jenkins is a continuous integration server" \
 
 # 8080 for main web interface, 50000 for slave agents
 EXPOSE 8080 50000
-RUN curl https://pkg.jenkins.io/redhat/jenkins.repo -o /etc/yum.repos.d/jenkins.repo && \
-    rpm --import https://pkg.jenkins.io/redhat/jenkins-ci.org.key && \
+RUN curl https://pkg.jenkins.io/redhat-stable/jenkins.repo -o /etc/yum.repos.d/jenkins.repo && \
+    rpm --import https://pkg.jenkins.io/redhat-stable/jenkins-ci.org.key && \
     yum install -y centos-release-scl-rh && \
     INSTALL_PKGS="rsync gettext git tar zip unzip java-1.8.0-openjdk java-1.8.0-openjdk.i686 java-1.8.0-openjdk-devel java-1.8.0-openjdk-devel.i686 jenkins-$JENKINS_VERSION" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \


### PR DESCRIPTION
This patch will update the jenkins version to
2.138.2-1.1 and also update the jenkins pkg link
to stable link

Fixes openshiftio/openshift.io#4461