### PR TITLE
Improves plugin storage fix and reduces the image size

### DIFF
--- a/2/contrib/s2i/assemble
+++ b/2/contrib/s2i/assemble
@@ -6,19 +6,6 @@ JENKINS_INSTALL_DIR=$(mktemp -d --suffix=jenkins)
 echo "---> Copying repository files ..."
 cp -Rf /tmp/src/. ${JENKINS_INSTALL_DIR}
 
-uncompress_plugins() {
-    pushd ${JENKINS_DIR}/plugins >/dev/null && {
-        for plugin in *.jpi *.hpi;do
-            base=$(echo ${plugin}|sed 's/.[hj]pi$//')
-            [[ -d ${base} ]] && continue # should not happen i think
-            mkdir -p ${base}
-            pushd ${base} >/dev/null && {
-                unzip ../${plugin}
-            } && popd >/dev/null
-        done
-    } && popd >/dev/null
-}
-
 # Install jenkins plugins using plugin installer if user has "plugins.txt" file
 # in repository
 if [ -f ${JENKINS_INSTALL_DIR}/plugins.txt ]; then
@@ -35,7 +22,6 @@ if [ -d ${JENKINS_INSTALL_DIR}/plugins ]; then
   echo "---> Installing $(ls -l ${JENKINS_INSTALL_DIR}/plugins | grep ^- | wc -l) Jenkins plugins from plugins/ directory ..."
   cp -R ${JENKINS_INSTALL_DIR}/plugins/* ${JENKINS_DIR}/plugins/
   /usr/local/bin/fix-permissions ${JENKINS_DIR}/plugins
-  uncompress_plugins
 fi
 
 if [ -d ${JENKINS_INSTALL_DIR}/configuration ]; then

--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -242,17 +242,24 @@ delete_plugins(){
   fi
 }
 
+clear_gluster_plugin() {
+    local plugins_dir = "${JENKINS_HOME}/plugins"
+
+    if [ ! -L "$plugins_dir" ]; then
+        echo "Removing existing $plugins_dir from gluster storage"
+        rm -rf $plugins_dir
+    fi
+}
+
 symlink_plugins() {
     if [ ! -L "${JENKINS_HOME}/plugins" ]; then
-        echo "Removing existing ${JENKINS_HOME}/plugins from gluster storage"
-        rm -rf ${JENKINS_HOME}/plugins
+        echo "Symlinking ${JENKINS_HOME}/plugins to /opt/openshift/plugins"
+        ln -sf /opt/openshift/plugins ${JENKINS_HOME}
     fi
-
-    echo "Symlinking ${JENKINS_HOME}/plugins to /opt/openshift/plugins"
-    ln -sf /opt/openshift/plugins ${JENKINS_HOME}
 }
 
 # We always use plugins from the image
+clear_gluster_plugin
 symlink_plugins
 
 echo "Creating initial Jenkins 'admin' user ..."

--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -243,7 +243,7 @@ delete_plugins(){
 }
 
 clear_gluster_plugin() {
-    local plugins_dir = "${JENKINS_HOME}/plugins"
+    local plugins_dir="${JENKINS_HOME}/plugins"
 
     if [ ! -L "$plugins_dir" ]; then
         echo "Removing existing $plugins_dir from gluster storage"

--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -243,22 +243,13 @@ delete_plugins(){
 }
 
 symlink_plugins() {
-    echo "Symlinking $(ls /opt/openshift/plugins | wc -l) Jenkins plugins to ${JENKINS_HOME} ..."
-    mkdir -p ${JENKINS_HOME}/plugins
+    if [ ! -L "${JENKINS_HOME}/plugins" ]; then
+        echo "Removing existing ${JENKINS_HOME}/plugins from gluster storage"
+        rm -rf ${JENKINS_HOME}/plugins
+    fi
 
-    ln -sf /opt/openshift/plugins/*.[jh]pi ${JENKINS_HOME}/plugins
-    cp -f /opt/openshift/plugins/version.txt ${JENKINS_HOME}/plugins
-
-    for i in /opt/openshift/plugins/*;do
-        for t in WEB META;do
-            [[ -d $i/${t}-INF ]] && {
-                a=${JENKINS_HOME}/plugins/$(basename $i)
-                [[ -d ${a} ]] || { echo "Plugin ${a} wasn't installed, let's wait for next boot."; continue ;}
-                rm -rf ${a}/${t}-INF
-                ln -sf ${i}/${t}-INF ${a}/
-            }
-        done
-    done
+    echo "Symlinking ${JENKINS_HOME}/plugins to /opt/openshift/plugins"
+    ln -sf /opt/openshift/plugins ${JENKINS_HOME}
 }
 
 # We always use plugins from the image


### PR DESCRIPTION
In last optimization, system used to link '/opt/openshift/plugins/*'
directory contents to `/var/lib/openshif/jenkins`, which contains
decompressed plugins directories in order prevent jenkins to extract
plugins on gluster storage. However, Jenkins used to override decompressed plugin
contents to make this patch effective Jenkins requires another boot.
Another issue was, how to cleanup existing plugins from gluster
storage when rolling out this plugin fix patch.

This patch creates symbolic link between the directory rather than directory contents,
which essentially eliminates the need to reboot jenkins twice to get decompressed plugins
content effective.
Now symbolic link is present between a directory, so let jenkins extract
the plugins in to `/opt/openshift/plugins` directory,
hence to reduce the image size system is not decompressing plugins
content upfront.

This patch also takes care of cleaning up the plugins from
gluster storage.

Fixes
 https://github.com/openshiftio/openshift.io/issues/4635